### PR TITLE
fixed: crashes

### DIFF
--- a/openb3dlib.mod/openb3d/src/material.cpp
+++ b/openb3dlib.mod/openb3d/src/material.cpp
@@ -820,6 +820,8 @@ void Shader::TurnOff(){
 		// reset texture matrix
 		glMatrixMode(GL_TEXTURE);
 		glLoadIdentity();
+
+		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 				
 		if (Shader_Tex[ix]->is3D==0){
 			glDisable(GL_TEXTURE_2D);

--- a/openb3dlib.mod/openb3d/src/voxel.cpp
+++ b/openb3dlib.mod/openb3d/src/voxel.cpp
@@ -338,6 +338,7 @@ void VoxelSprite::Render(){
 	
 		glDisable(GL_TEXTURE_3D);
 	}
+	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 }
 
 


### PR DESCRIPTION
uv arrays were not disabled in voxel rendering and after disabling shaders, which would cause driver segfaults when rendering clientside vertex arrays without uvs (guess you just got lucky with vbos)
