### PR TITLE
Fixed a crash bug with freeing animated meshes

### DIFF
--- a/openb3dlib.mod/openb3d/src/entity.cpp
+++ b/openb3dlib.mod/openb3d/src/entity.cpp
@@ -27,10 +27,8 @@ void Entity::FreeEntity(void){
 	entity_list.remove(this);
 
 	// remove from animate list
-	if(anim_update){
-		animate_list.remove(this);
-		anim_update=false;
-	}
+	animate_list.remove(this);
+	anim_update=false;
 
 	// remove from collision entity lists
 	if(collision_type!=0) CollisionPair::ent_lists[collision_type].remove(this);


### PR DESCRIPTION
Ever since I started working with OpenB3D on my project, I've always had random inconsistant issues with using FreeEntity on animated meshes, and having the whole project crash on the next UpdateWorld().
But the workaround I've had in the root of my project since 2017 was just a custom FreeEntity function where it calls something like:

Function KFreeEntity(ent:TEntity)
  Animate(ent, 0)
  FreeEntity(ent)
End Function

However now that I've added a lot more content to the project, I've noticed this issue starting to return seemingly at random again.
Although it doesn't crash nearly as much as it does without the Animate(ent, 0) part.

It seems the issue starts from Global.cpp, UpdateEntityAnim was being called on entities that should have been freed with FreeEntity.
Which then traced back to entity.cpp, where it seems the code for deleting the "animate_list" would only happen if anim_update was true.
Which in a lot of cases it may be false (such as using SetAnimTime would set it to false) 

Deleting the "if" check seems to fix the entire issue, I've been testing for an hour or so with no issues, including on other entities such as pivots and sprites.

Horray! Found the root cause after all this time! (hopefully)